### PR TITLE
Karma

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ Browserify lets you require(‘modules’) in the browser by bundling up all of 
 
 [https://github.com/babel/babelify](https://github.com/babel/babelify)
 
-Combines the [Babel](https://github.com/babel/babel) js compiler to worth with `Browserify`
+[Babel](https://github.com/babel/babel) Allows new ES6 syntax to be used.
+
+Combines the [Babel](https://github.com/babel/babel) js compiler to work with `Browserify`
 
 ### Watchify
 
@@ -52,4 +54,22 @@ Auto re-compiles any changes you make to the js files automatically for you.
 
 [https://facebook.github.io/flux/](https://facebook.github.io/flux/)
 
-An application architecture for React utilizing a unidirectional data flow.
+"An application architecture for React utilizing a unidirectional data flow."
+
+Essentially it allows us to easily share state between isolated components.
+
+### Karma
+
+[https://karma-runner.github.io](https://karma-runner.github.io)
+
+Karma is a test runner we use for running the specs.
+
+It is configured to run the specs in a headless PhantomJS browser.
+
+It also handles Browserify, Babelify and auto-reloading the specs.
+
+### Jasmine
+
+[http://jasmine.github.io/](http://jasmine.github.io/)
+
+Jasmine is the testing framework we use for writing the specs.

--- a/js/actions/actions.js
+++ b/js/actions/actions.js
@@ -1,5 +1,5 @@
-var Dispatcher = require('../dispatcher/dispatcher');
-var Constants = require('../constants/constants');
+import Dispatcher from '../dispatcher/dispatcher';
+import Constants from '../constants/constants';
 
 var Actions = {
   updateTrack: (track) => {

--- a/js/utils/jukebox.js
+++ b/js/utils/jukebox.js
@@ -6,8 +6,8 @@ class Jukebox {
   }
 
   websocketServerURI() {
-    return('ws://localhost:8081');
-    //return('ws://jukebox.local:8081');
+    //return('ws://localhost:8081');
+    return('ws://jukebox.local:8081');
   }
 
   openConnection() {

--- a/js/utils/jukebox.js
+++ b/js/utils/jukebox.js
@@ -118,4 +118,4 @@ class Jukebox {
   // }
 }
 
-export default Jukebox;
+module.exports = Jukebox;

--- a/karma.config.js
+++ b/karma.config.js
@@ -1,0 +1,69 @@
+module.exports = function(config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['jasmine', 'browserify'],
+
+    // list of files / patterns to load in the browser
+    files: [
+      'specs/**/*_spec.js'
+    ],
+
+    // list of files to exclude
+    exclude: [
+    ],
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+      'specs/**/*.js': ['browserify']
+    },
+
+    browserify: {
+      debug: false,
+      transform: [
+        [
+          'babelify',
+          {
+            'presets': [ 'es2015' ],
+            'plugins': [ 'transform-class-properties' ]
+          }
+        ]
+      ]
+    },
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['progress'],
+
+    // web server port
+    port: 9876,
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['PhantomJS'],
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: false,
+
+    // Concurrency level
+    // how many browser should be started simultaneous
+    concurrency: Infinity
+  })
+}

--- a/package.json
+++ b/package.json
@@ -18,9 +18,16 @@
   },
   "devDependencies": {
     "babel-cli": "^6.8.0",
-    "browserify": "^6.2.0",
+    "babel-preset-es2015": "^6.9.0",
+    "browserify": "^13.0.1",
     "envify": "^3.0.0",
-    "jasmine-node": "^1.14.5",
+    "jasmine-core": "^2.4.1",
+    "karma": "^0.13.22",
+    "karma-babel-preprocessor": "^6.0.1",
+    "karma-browserify": "^5.0.5",
+    "karma-jasmine": "^1.0.2",
+    "karma-phantomjs-launcher": "^1.0.0",
+    "phantomjs-prebuilt": "^2.1.7",
     "reactify": "^0.15.2",
     "uglify-js": "~2.4.15",
     "watchify": "^3.7.0"
@@ -28,7 +35,7 @@
   "scripts": {
     "start": "watchify -t babelify -v -d js/app.js -o js/bundle.js",
     "build": "browserify . -t [envify --NODE_ENV production] -t [babelify] | uglifyjs -cm > js/bundle.min.js",
-    "test": "jasmine-node specs"
+    "test": "./node_modules/karma/bin/karma start --auto-watch --no-single-run karma.config.js"
   },
   "babel": {
     "plugins": [
@@ -42,11 +49,7 @@
   "author": "Kyan",
   "browserify": {
     "transform": [
-      "reactify",
-      "envify"
+      "reactify"
     ]
-  },
-  "jest": {
-    "rootDir": "./js"
   }
 }

--- a/specs/utils/jukebox_spec.js
+++ b/specs/utils/jukebox_spec.js
@@ -1,4 +1,4 @@
-import Jukebox from './../js/utils/jukebox/jukebox';
+import Jukebox from './../../js/utils/jukebox';
 
 describe('Jukebox', () => {
   let instance;


### PR DESCRIPTION
Specs are now running via:

    $ npm test

I've set the specs to run via [Karma](https://karma-runner.github.io/0.13/index.html) as this handles the various plugins and libraries that allows us to use ES6 syntax. It also uses headless [PhantomJS](http://phantomjs.org/) and auto reloads the specs.